### PR TITLE
Split "args" from "options" in command-line

### DIFF
--- a/lib/Retcon/Store/PostgreSQL.hs
+++ b/lib/Retcon/Store/PostgreSQL.hs
@@ -220,10 +220,10 @@ storeOneDiff conn isConflict ik d = do
 
 -- | Load the parameters from the path specified in the options.
 prepareConfig
-    :: RetconOptions
+    :: (RetconOptions, [Text])
     -> [entity]
     -> IO (RetconConfig entity RWToken)
-prepareConfig opt entities = do
+prepareConfig (opt, event) entities = do
     params <- maybe (return mempty) readParams $ opt ^. optParams
     store :: PGStorage <- storeInitialise opt
     return $ RetconConfig
@@ -231,7 +231,7 @@ prepareConfig opt entities = do
         (opt ^. optLogging)
         (token store)
         params
-        (opt ^. optArgs)
+        event
         entities
   where
     readParams :: FilePath -> IO (Map (Text, Text) (Map Text Text))

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -143,10 +143,10 @@ jsonFilePath = liftIO $
 -- | Parse event from command line and execute it.
 main :: IO ()
 main = do
-    opts <- parseArgsWithConfig "/etc/retcon.conf"
-    cfg <- prepareConfig opts entities
+    (opts, event) <- parseArgsWithConfig "/etc/retcon.conf"
+    cfg <- prepareConfig (opts, event) entities
     when (opts ^. optVerbose) $ print opts
 
-    let (entity:source:key:_) = opts ^. optArgs
+    let (entity:source:key:_) = event
     res <- retcon cfg $ show (entity, source, key)
     print res

--- a/tests/HandlerTest.hs
+++ b/tests/HandlerTest.hs
@@ -419,10 +419,9 @@ dispatchSuite = do
                 (fk, doc) <- newTestDocument "dispatch1-" Nothing ref1
 
                 -- Dispatch the event.
-                let opts' = opts & optArgs .~ ["dispatchtest", "dispatch1", fk]
                 let input = ("dispatchtest", "dispatch1", T.unpack fk)
 
-                res <- run opts' state store $ dispatch input
+                res <- run opts state store $ dispatch input
 
                 -- The document should be present in both stores, with an
                 -- InternalKey and two ForeignKeys.
@@ -450,9 +449,8 @@ dispatchSuite = do
                 -- still empty.
 
                 -- Dispatch the event.
-                let opts' = opts & optArgs .~ ["dispatchtest", "dispatch1", "999"]
                 let input = ("dispatchtest", "dispatch1", "999")
-                res <- run opts' state store $ dispatch input
+                res <- run opts state store $ dispatch input
 
                 -- Check that there are still no InternalKey or ForeignKey
                 -- details in the database.
@@ -716,7 +714,7 @@ runRetconHandler opt state store a =
                 (opt ^. optLogging)
                 (token store)
                 mempty
-                (opt ^. optArgs)
+                []
                 state
   in runRetconMonad (RetconMonadState cfg ()) a
 

--- a/tests/PostgreSQLTest.hs
+++ b/tests/PostgreSQLTest.hs
@@ -167,7 +167,7 @@ run l a = do
                 (opt ^. optLogging)
                 store'
                 mempty
-                (opt ^. optArgs)
+                []
                 state
     result <- runRetconMonad (RetconMonadState cfg l) a
     storeFinalise store

--- a/tests/StorePostgreSQL.hs
+++ b/tests/StorePostgreSQL.hs
@@ -49,7 +49,7 @@ runAction store =
                 (options ^. optLogging)
                 (token store)
                 mempty
-                (options ^. optArgs)
+                []
                 []
     in runRetconMonad (RetconMonadState cfg ())
 

--- a/tests/UserAPITest.hs
+++ b/tests/UserAPITest.hs
@@ -78,7 +78,7 @@ run l a = do
                 (opt ^. optLogging)
                 store'
                 mempty
-                (opt ^. optArgs)
+                mempty
                 state
     result <- runRetconMonad (RetconMonadState cfg l) a
     storeFinalise store


### PR DESCRIPTION
Separate the data types and parsers for the configuration-y "options"
and the command-y "arguments".

This results in parsers which are more readily reused in client code.
