### PR TITLE
Convert merge policy to operate on list of patches

### DIFF
--- a/lib/Retcon/Diff.hs
+++ b/lib/Retcon/Diff.hs
@@ -30,8 +30,6 @@ module Retcon.Diff
      , rejectedOperation
      ) where
 
-import           Debug.Trace
-
 import           Control.Applicative
 import           Control.Lens        hiding ((.=))
 import qualified Data.Aeson.Diff     as D

--- a/test/policy-test.hs
+++ b/test/policy-test.hs
@@ -38,19 +38,19 @@ suite = do
         it "should accept changes that do not conflict" $
             accepted `shouldBe` mkPatch Nothing
                                         [ Ins [D.OKey "pet"] "cat"
-                                        , Ins [D.OKey "owner"] "Doge"
-                                        , Del [D.OKey "color"] "pink"
                                         , Del [D.OKey "size"] "small"
                                         , Ins [D.OKey "size"] "medium"
+                                        , Ins [D.OKey "owner"] "Doge"
+                                        , Del [D.OKey "color"] "pink"
                                         ]
 
         it "should ignore all changes which conflict" $
-            rejected `shouldBe` map mkRej [ Del [D.OKey "food"] ""
-                                          , Ins [D.OKey "food"] "grass"
+            rejected `shouldBe` map mkRej [ Ins [D.OKey "value"] "one"
                                           , Del [D.OKey "type"] "zebra"
-                                          , Ins [D.OKey "type"] "goat"
-                                          , Ins [D.OKey "value"] "one"
                                           , Ins [D.OKey "value"] "two"
+                                          , Del [D.OKey "food"] ""
+                                          , Ins [D.OKey "food"] "grass"
+                                          , Ins [D.OKey "type"] "goat"
                                           , Del [D.OKey "value"] "$$$"
                                           ]
 

--- a/test/policy-test.hs
+++ b/test/policy-test.hs
@@ -16,6 +16,8 @@ suite = do
                  [ Ins [D.OKey "value"] "one"
                  , Ins [D.OKey "pet"] "cat"
                  , Del [D.OKey "type"] "zebra"
+                 , Del [D.OKey "size"] "small"
+                 , Ins [D.OKey "size"] "medium"
                  ]
 
             d2 = mkPatch Nothing
@@ -38,6 +40,8 @@ suite = do
                                         [ Ins [D.OKey "pet"] "cat"
                                         , Ins [D.OKey "owner"] "Doge"
                                         , Del [D.OKey "color"] "pink"
+                                        , Del [D.OKey "size"] "small"
+                                        , Ins [D.OKey "size"] "medium"
                                         ]
 
         it "should ignore all changes which conflict" $

--- a/test/policy-test.hs
+++ b/test/policy-test.hs
@@ -35,20 +35,19 @@ suite = do
 
         it "should accept changes that do not conflict" $
             accepted `shouldBe` mkPatch Nothing
-                                        [ Del [D.OKey "value"] "$$$"
-                                        , Ins [D.OKey "pet"] "cat"
+                                        [ Ins [D.OKey "pet"] "cat"
                                         , Ins [D.OKey "owner"] "Doge"
                                         , Del [D.OKey "color"] "pink"
                                         ]
 
         it "should ignore all changes which conflict" $
-            rejected `shouldBe` map mkRej [ Ins [D.OKey "value"] "one"
-                                          , Ins [D.OKey "value"] "two"
-                                          , Del [D.OKey "value"] "$$$"
-                                          , Del [D.OKey "food"] ""
+            rejected `shouldBe` map mkRej [ Del [D.OKey "food"] ""
                                           , Ins [D.OKey "food"] "grass"
                                           , Del [D.OKey "type"] "zebra"
                                           , Ins [D.OKey "type"] "goat"
+                                          , Ins [D.OKey "value"] "one"
+                                          , Ins [D.OKey "value"] "two"
+                                          , Del [D.OKey "value"] "$$$"
                                           ]
 
     describe "rejectAll merge policy" $ do


### PR DESCRIPTION
This branch changes `Retcon.Diff` to merge *lists* of `Patch`es rather than pairs. This is required to implement `ignoreConflicts` properly.