### PR TITLE
Output failure messages from datasources rather than discarding them

### DIFF
--- a/retcon.cabal
+++ b/retcon.cabal
@@ -1,5 +1,5 @@
 name:                retcon
-version:             2.0.0.0
+version:             2.0.0.1
 synopsis:            Daemon to propagate changes between JSON stores.
 description:
   Retcon is a library and program to detect, extract, merge and propagate


### PR DESCRIPTION
Very hard to debug transient errors in datasource updates when the
only log message is "exited with error".